### PR TITLE
docs: add cross-reference to Hive (alternative form factor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,16 @@ squad receive worker --json
 squad send manager @all "API contract changed, update your implementations"
 ```
 
+## Other form factors
+
+squad takes the **pure CLI + SQLite + one terminal per agent** route. It fits best when you:
+
+- live in tmux, or SSH into remote dev boxes
+- want to keep your own terminal emulator
+- don't want any extra background process running
+
+If you'd prefer a visual workbench — task graph UI, one-click restart all, workspace sidebar — take a look at [Hive](https://hivehq.dev/). Hive drives Claude / Codex / Gemini / OpenCode the same way (real CLI processes), but the PTYs run in a browser. The two projects don't replace each other; pick by workflow.
+
 ## Requirements
 
 - Rust 1.77+ (for building)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -287,6 +287,16 @@ squad receive worker --json
 squad send manager @all "API 接口已更新，请更新你们的实现"
 ```
 
+## 别的形态
+
+squad 走的是 **纯 CLI + SQLite + 每个 agent 一个终端** 的路线，最适合：
+
+- 习惯 tmux、或通过 SSH 进远端服务器开发
+- 想保留自己的终端模拟器
+- 不想跑任何额外后台进程
+
+如果你更想要一个可视化工作台——任务图 UI、一键重启所有 worker、侧边栏切换 workspace——可以看看 [Hive](https://hivehq.dev/)。Hive 同样把 Claude / Codex / Gemini / OpenCode 当真实 CLI 进程驱动，PTY 跑在浏览器里。两个项目互不替代，按工作流挑就行。
+
 ## 系统要求
 
 - Rust 1.77+（编译需要）


### PR DESCRIPTION
## Summary

squad and [Hive](https://hivehq.dev/) solve the same problem — coordinating
multiple CLI agents (Claude / Codex / Gemini / OpenCode) on one project —
with different form factors. This PR adds a short **"Other form factors"**
section near the bottom of both READMEs (zh + en) so people landing on
squad can pick the right tool by workflow, rather than discovering Hive
months later.

The framing is intentionally **neutral**:

- squad — pure CLI + SQLite, lives in tmux, SSH-friendly, zero background process
- Hive — visual workbench in the browser, task graph UI, one-click restart all

Closing line is "the two projects don't replace each other; pick by workflow"
so it reads as informational, not promotional.

Hive's own README has a mirrored section pointing back at squad (commit
[`fee546c`](https://github.com/tt-a1i/hive/commit/fee546c) in the Hive repo).

## Test plan

- [x] Both READMEs render correctly on GitHub
- [x] Section placement is consistent (zh + en both before Requirements / 系统要求)
- [x] Link to https://hivehq.dev/ resolves